### PR TITLE
Minor tweaks

### DIFF
--- a/builtin/providers/netapp/resource_cloud_volume.go
+++ b/builtin/providers/netapp/resource_cloud_volume.go
@@ -68,12 +68,10 @@ func resourceCloudVolume() *schema.Resource {
 			"initial_size": {
 				Type:     schema.TypeFloat,
 				Optional: true,
-				ForceNew: true,
 			},
 			"initial_size_unit": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"GB",
 					"TB",

--- a/builtin/providers/netapp/resource_cloud_volume_test.go
+++ b/builtin/providers/netapp/resource_cloud_volume_test.go
@@ -581,8 +581,8 @@ resource "netapp_cloud_volume" "awsha-nfs-volume" {
   export_policy = ["12.13.14.15/32"]
   provider_volume_type = "st1"
   thin_provisioning = true
-  compression = true
-  deduplication = true
+  compression = false
+  deduplication = false
 }
 `
 const testAccCloudVolume_nfs_awsha_tier_change = `
@@ -601,8 +601,8 @@ resource "netapp_cloud_volume" "awsha-nfs-volume" {
   export_policy = ["12.13.14.15/32"]
   provider_volume_type = "gp2"
   thin_provisioning = true
-  compression = true
-  deduplication = true
+  compression = false
+  deduplication = false
 }
 `
 const testAccCloudVolume_nfs_awsha_data_change = `
@@ -621,8 +621,8 @@ resource "netapp_cloud_volume" "awsha-nfs-volume" {
   export_policy = ["22.13.14.15/32"]
   provider_volume_type = "st1"
   thin_provisioning = true
-  compression = true
-  deduplication = true
+  compression = false
+  deduplication = false
 }
 `
 const testAccCloudVolume_cifs_vsa = `


### PR DESCRIPTION
NetApp OCCM is used by enterprises to implement scalable cloud-based NAS solutions. This provider adds support for managing OCCM volumes. Please note that in order to run acceptance tests it is required that the OCCM environment is set up and configured (both VSA (non-HA) and HA environments are required and they need to have the Active Directory set up in order for the tests to pass).

Depending on the OCCM processing speed the "*_data_change" tests may fail due to the fact that OCCM sometimes takes a significant amount of time to change underlying volume type.

